### PR TITLE
fix empty plain object clone

### DIFF
--- a/src/util/clone.js
+++ b/src/util/clone.js
@@ -46,7 +46,12 @@ var clone = function(obj) {
     if (obj instanceof Array) {
         return cloneArray(obj);
     }
-    newInstance = new obj.constructor();
+    if (typeof obj.constructor === 'function') {
+        newInstance = new obj.constructor();
+    } else {
+        newInstance = {};
+    }
+    
     return cloneProperties(newInstance,obj);
 };
 


### PR DESCRIPTION
I have error on call service with empty plain object

`doThing({}).then(...)`

> TypeError: undefined is not a function
>   at clone (/project/node_modules/studio/src/util/clone.js:56:19)